### PR TITLE
fix: add webdriver-manager to match the driver and chrome

### DIFF
--- a/chromegpt/tools/selenium.py
+++ b/chromegpt/tools/selenium.py
@@ -9,6 +9,7 @@ import validators
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
 from selenium.common.exceptions import (
     WebDriverException,
 )
@@ -50,7 +51,7 @@ class SeleniumWrapper:
                 options=chrome_options,
             )
         else:
-            self.driver = webdriver.Chrome(options=chrome_options)
+            self.driver = webdriver.Chrome(ChromeDriverManager().install(), options=chrome_options)
         self.driver.implicitly_wait(5)  # Wait 5 seconds for elements to load
 
     def __del__(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ validators = "^0.20.0"
 pexpect = "^4.8.0"
 unidecode = "1.3.6"
 bs4 = "^0.0.1"
+webdriver-manager = "^4.0.0"
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
Hi, erlichsefi, thank you fo open source this fun project!    after clone the repo and play without docker, I got a selenium error, It seem about chromeDriver mismatch with my chrome

```bash
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 114
Current browser version is 116.0.5845.179 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```
After search around I find a solution from: https://stackoverflow.com/questions/60296873/sessionnotcreatedexception-message-session-not-created-this-version-of-chrome
